### PR TITLE
Allow for multiple bot admin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ ENV Variable | Description
 | TELEGRAM_ADMIN    | The Telegram user id for the admin |
 | TELEGRAM_TOKEN    | Token you get from [@botfather](https://telegram.me/botfather) |
 
+#### Authentication
+
+Additional users may be allowed to command the bot by giving multiple instances
+of the `--telegram.admin` command line option or by specifying a
+newline-separated list of telegram user IDs in the `TELEGRAM_ADMIN` environment
+variable.
+
 #### Alertmanager Configuration 
 
 Now you need to connect the Alertmanager to send alerts to the bot.  
@@ -194,11 +201,6 @@ alertmanager-bot
 * `/silence` - show a specific silence  
 * `/silence_del` - delete a silence by command  
 * `/silence_add` - add a silence for a alert by command
-
-##### Authentication
-
-Right now only one user can use the bot by giving the bot one telegram user id.  
-Others can just read what the Bot sends to a group chat.
 
 ##### More Messengers
 

--- a/cmd/alertmanager-bot/main.go
+++ b/cmd/alertmanager-bot/main.go
@@ -48,15 +48,15 @@ func main() {
 	godotenv.Load()
 
 	config := struct {
-		alertmanager  *url.URL
-		boltPath      string
-		consul        *url.URL
-		listenAddr    string
-		logLevel      string
-		logJSON       bool
-		store         string
-		telegramAdmin int
-		telegramToken string
+		alertmanager   *url.URL
+		boltPath       string
+		consul         *url.URL
+		listenAddr     string
+		logLevel       string
+		logJSON        bool
+		store          string
+		telegramAdmins []int
+		telegramToken  string
 	}{}
 
 	a := kingpin.New("alertmanager-bot", "Bot for Prometheus' Alertmanager")
@@ -97,7 +97,7 @@ func main() {
 	a.Flag("telegram.admin", "The ID of the initial Telegram Admin").
 		Required().
 		Envar("TELEGRAM_ADMIN").
-		IntVar(&config.telegramAdmin)
+		IntsVar(&config.telegramAdmins)
 
 	a.Flag("telegram.token", "The token used to connect with Telegram").
 		Required().
@@ -164,12 +164,13 @@ func main() {
 		}
 
 		bot, err := telegram.NewBot(
-			chats, config.telegramToken, config.telegramAdmin,
+			chats, config.telegramToken, config.telegramAdmins[0],
 			telegram.WithLogger(tlogger),
 			telegram.WithAddr(config.listenAddr),
 			telegram.WithAlertmanager(config.alertmanager),
 			telegram.WithRevision(Revision),
 			telegram.WithStartTime(StartTime),
+			telegram.WithExtraAdmins(config.telegramAdmins[1:]...),
 		)
 		if err != nil {
 			level.Error(tlogger).Log("msg", "failed to create bot", "err", err)


### PR DESCRIPTION
This PR allows users to specify multiple admin IDs for the bot to accept commands from. Useful when bot operation is done in a team that doesn't share Telegram accounts. We've been carrying this patch locally for a while now and I just rebased it onto current master.

I've opted to use an additional BotOption for providing further IDs as to not disturb any possible existing users. Happy to rework that, if you think that's better (especially considering that pkg/telegram is a very recent development and at least GoDoc doesn't know about any public external users yet).

Existing usage of the relevant command line flags keeps its meaning and is unaffected by this change. 