### PR TITLE
document what the admin user IDs are used for

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ ENV Variable | Description
 | CONSUL_URL        | The URL to use to connect with Consul, default: `localhost:8500` |
 | LISTEN_ADDR       | Address that the bot listens for webhooks, default: `0.0.0.0:8080` |
 | STORE             | The type of the store to use, choose from bolt (local) or consul (distributed) |
-| TELEGRAM_ADMIN    | The Telegram user id for the admin |
+| TELEGRAM_ADMIN    | The Telegram user id for the admin. The bot will only reply to messages sent from an admin. All other messages are dropped and logged on the bot's console. |
 | TELEGRAM_TOKEN    | Token you get from [@botfather](https://telegram.me/botfather) |
 | TEMPLATE_PATHS    | Path to custom message templates, default template is `./default.tmpl`, in docker - `/templates/default.tmpl` |
 


### PR DESCRIPTION
This adds minimal information to the docs what the admin user IDs are used for. 

Alternative: a separated paragraph "Security" could take 1-2 sentences what admins can do (and other users can't).