### PR TITLE
readme: fix go get instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ alertmanager-bot:
 ```
 ### Build from source
 
-`go get github.com/metalmatze/alertmanager-bot`
+`GO111MODULE=on go get github.com/metalmatze/alertmanager-bot/cmd/alertmanager-bot`
 
 ### Configuration
 


### PR DESCRIPTION
The documented go get instruction no longer works. First, the project seems to use go modules now. Second, we need to reference the URL of the main-providing package to actually end up with a working binary. This fixes it.