### PR TITLE
refact: Dockerfile is now a multistage scratch build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# Except the default template and the binary
+!default.tmpl
+!alertmanager-bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
-FROM alpine:latest
-ENV TEMPLATE_PATHS=/templates/default.tmpl
-RUN apk add --update ca-certificates
+FROM alpine:latest as alpine
 
-COPY ./default.tmpl /templates/default.tmpl
+# Install the latest SSL certificates
+RUN apk add --no-cache ca-certificates
+
+# Create a non privileged user
+RUN echo "nobody:x:65534:65534:Nobody:/:" > /etc_passwd
+
+# Start new scratch built for security and minimal footprint
+FROM scratch
+ENV TEMPLATE_PATHS=/templates/default.tmpl
+
+# Add SSL certificates from the previous alpine stage
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Copy the unprivileged user
+COPY --from=alpine /etc_passwd /etc/passwd
+
+# Copy default template and alertmanager-bot binary
+# NOTE: When adding a copy here, don't forget to add it in the .dockerignore
+COPY ./default.tmpl ${TEMPLATE_PATHS}
 COPY ./alertmanager-bot /usr/bin/alertmanager-bot
 
 EXPOSE 8080
-
 ENTRYPOINT ["/usr/bin/alertmanager-bot"]
+USER nobody


### PR DESCRIPTION
This moves the Go binary in a Docker scratch container for minimal footprint and better security (no shell available and running as non-root).

See this article for the rationale behind these changes:
https://weberc2.bitbucket.io/posts/golang-docker-scratch-app.html

Also adds a .dockerignore that excludes all the files except the ones used within the Dockerfile. Running docker build after `make release` sends 198.2MB to the Docker daemon, this is now reduced to 13.4MB.
On my system it was a noticeable speed improvement of 42 seconds :)
```
docker build . -t test --no-cache  0.06s user 0.14s system 2% cpu 9.741 total
docker build . -t test --no-cache  0.48s user 1.92s system 12% cpu 18.871 total
```