### PR TITLE
Fix flags with defaults that aren't required anymore

### DIFF
--- a/cmd/alertmanager-bot/main.go
+++ b/cmd/alertmanager-bot/main.go
@@ -71,7 +71,6 @@ func main() {
 	a.HelpFlag.Short('h')
 
 	a.Flag("alertmanager.url", "The URL that's used to connect to the alertmanager").
-		Required().
 		Envar("ALERTMANAGER_URL").
 		Default("http://localhost:9093/").
 		URLVar(&config.alertmanager)
@@ -87,7 +86,6 @@ func main() {
 		URLVar(&config.consul)
 
 	a.Flag("listen.addr", "The address the alertmanager-bot listens on for incoming webhooks").
-		Required().
 		Envar("LISTEN_ADDR").
 		Default("0.0.0.0:8080").
 		StringVar(&config.listenAddr)


### PR DESCRIPTION
There were 2 flags that I added defaults to and by mistake left them to be required. This is a fix.

Closes #95 