### PR TITLE
Support description annotation which is used by newer alerts

### DIFF
--- a/default.tmpl
+++ b/default.tmpl
@@ -5,6 +5,9 @@
 {{ if .Annotations.message }}
 {{ .Annotations.message }}
 {{ end }}
+{{ if .Annotations.summary }}
+{{ .Annotations.summary }}
+{{ end }}
 {{ if .Annotations.description }}
 {{ .Annotations.description }}
 {{ end }}

--- a/default.tmpl
+++ b/default.tmpl
@@ -2,7 +2,12 @@
 {{ range .Alerts }}
 {{ if eq .Status "firing"}}🔥 <b>{{ .Status | toUpper }}</b> 🔥{{ else }}<b>{{ .Status | toUpper }}</b>{{ end }}
 <b>{{ .Labels.alertname }}</b>
+{{ if .Annotations.message }}
 {{ .Annotations.message }}
+{{ end }}
+{{ if .Annotations.description }}
+{{ .Annotations.description }}
+{{ end }}
 <b>Duration:</b> {{ duration .StartsAt .EndsAt }}{{ if ne .Status "firing"}}
 <b>Ended:</b> {{ .EndsAt | since }}{{ end }}
 {{ end }}


### PR DESCRIPTION
I am not 100% sure if this works please double check...

The current template lacks description support and the duration could also be hidden if there is no end date? In my tests it is "-" until the event is solved.