### PR TITLE
Create jsonnet-based deployments for Kubernets and Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 /.env
 /alertmanager-bot
-/data.yml
+/deployments/examples/data
 /dist/
-/vendor/
 
 *coverage.out
 

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,13 @@ release:
 		$(GO) get -u github.com/mitchellh/gox; \
 	fi
 	CGO_ENABLED=0 gox -arch="386 amd64 arm" -verbose -ldflags '-w $(LDFLAGS)' -output="dist/$(EXECUTABLE)-${DRONE_TAG}-{{.OS}}-{{.Arch}}" ./cmd/alertmanager-bot/
+
+deployments/examples/kubernetes.yaml: deployments/examples/kubernetes.jsonnet deployments/examples/values.jsonnet deployments/kubernetes.libsonnet
+	jsonnetfmt -i deployments/kubernetes.libsonnet
+	jsonnetfmt -i deployments/examples/kubernetes.jsonnet
+	jsonnet deployments/examples/kubernetes.jsonnet | gojsontoyaml > deployments/examples/kubernetes.yaml
+
+deployments/examples/docker-compose.yaml: deployments/examples/docker-compose.jsonnet deployments/examples/values.jsonnet deployments/docker-compose.libsonnet
+	jsonnetfmt -i deployments/docker-compose.libsonnet
+	jsonnetfmt -i deployments/examples/docker-compose.jsonnet
+	jsonnet deployments/examples/docker-compose.jsonnet | gojsontoyaml > deployments/examples/docker-compose.yaml

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ release:
 	fi
 	CGO_ENABLED=0 gox -arch="386 amd64 arm" -verbose -ldflags '-w $(LDFLAGS)' -output="dist/$(EXECUTABLE)-${DRONE_TAG}-{{.OS}}-{{.Arch}}" ./cmd/alertmanager-bot/
 
+README.md: deployments/examples/docker-compose.yaml deployments/examples/kubernetes.yaml
+	embedmd -w README.md
+
 deployments/examples/kubernetes.yaml: deployments/examples/kubernetes.jsonnet deployments/examples/values.jsonnet deployments/kubernetes.libsonnet
 	jsonnetfmt -i deployments/kubernetes.libsonnet
 	jsonnetfmt -i deployments/examples/kubernetes.jsonnet

--- a/deployments/docker-compose.libsonnet
+++ b/deployments/docker-compose.libsonnet
@@ -1,0 +1,44 @@
+function(params) {
+  local bot = {
+    log: {
+      level: 'info',
+      json: false,
+    },
+  } + params,
+
+  version: '3',
+  networks: {
+    'alertmanager-bot': {},
+  },
+  services: {
+    'alertmanager-bot': {
+      image: bot.image,
+      restart: 'always',
+      networks: ['alertmanager-bot'],
+      environment: if std.objectHas(bot, 'telegram') then {
+        TELEGRAM_ADMIN: bot.telegram.admin,
+        TELEGRAM_TOKEN: bot.telegram.token,
+      } else {},
+      command: [
+        '--alertmanager.url=%s' % bot.alertmanager.url,
+        '--log.level=%s' % bot.log.level,
+      ] + (
+        if bot.log.json then ['--log.json'] else []
+      ) + (
+        if std.objectHas(bot.storage, 'bolt') then [
+          '--store=bolt',
+          '--bolt.path=%s' % bot.storage.bolt.path,
+        ] else []
+      ) + (
+        if std.objectHas(bot.storage, 'consul') then [
+          '--store=consul',
+          '--consul.url=%s' % bot.storage.consul.url,
+        ] else []
+      ),
+      ports: [
+        '%d:%d' % [bot.ports[name], bot.ports[name]]
+        for name in std.objectFields(bot.ports)
+      ],
+    },
+  },
+}

--- a/deployments/examples/docker-compose.jsonnet
+++ b/deployments/examples/docker-compose.jsonnet
@@ -1,0 +1,16 @@
+local compose = import '../docker-compose.libsonnet';
+local values = import 'values.jsonnet';
+
+compose(values) + {
+  // Overwrite with custom values
+  services+: {
+    'alertmanager-bot'+: {
+      // ports: [
+      //   '80:8080/tcp',
+      // ],
+      volumes: [
+        './data:/data',
+      ],
+    },
+  },
+}

--- a/deployments/examples/docker-compose.yaml
+++ b/deployments/examples/docker-compose.yaml
@@ -1,0 +1,21 @@
+networks:
+  alertmanager-bot: {}
+services:
+  alertmanager-bot:
+    command:
+    - --alertmanager.url=http://localhost:9093
+    - --log.level=info
+    - --store=bolt
+    - --bolt.path=/data/bot.db
+    environment:
+      TELEGRAM_ADMIN: "1234"
+      TELEGRAM_TOKEN: XXXXXXX
+    image: metalmatze/alertmanager-bot:0.4.2
+    networks:
+    - alertmanager-bot
+    ports:
+    - 8080:8080
+    restart: always
+    volumes:
+    - ./data:/data
+version: "3"

--- a/deployments/examples/kubernetes.jsonnet
+++ b/deployments/examples/kubernetes.jsonnet
@@ -1,0 +1,24 @@
+local kubernetes = import '../kubernetes.libsonnet';
+local values = import 'values.jsonnet';
+
+local k = kubernetes(values) + {
+  // Overwrite or add thing here
+  statefulSet+: {
+    spec+: {
+      template+: {
+        spec+: {
+          restartPolicy: 'Always',
+        },
+      },
+    },
+  },
+};
+
+{
+  apiVersion: 'v1',
+  kind: 'List',
+  items: [
+    k[object]
+    for object in std.objectFields(k)
+  ],
+}

--- a/deployments/examples/kubernetes.yaml
+++ b/deployments/examples/kubernetes.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  data:
+    admin: MTIzNA==
+    token: WFhYWFhYWA==
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/name: alertmanager-bot
+    name: alertmanager-bot
+    namespace: monitoring
+  type: Opaque
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: alertmanager-bot
+    name: alertmanager-bot
+    namespace: monitoring
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+    selector:
+      app.kubernetes.io/name: alertmanager-bot
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/name: alertmanager-bot
+    name: alertmanager-bot
+    namespace: monitoring
+  spec:
+    podManagementPolicy: OrderedReady
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: alertmanager-bot
+    serviceName: alertmanager-bot
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: alertmanager-bot
+        name: alertmanager-bot
+        namespace: monitoring
+      spec:
+        containers:
+        - args:
+          - --alertmanager.url=http://localhost:9093
+          - --log.level=info
+          - --store=bolt
+          - --bolt.path=/data/bot.db
+          env:
+          - name: TELEGRAM_ADMIN
+            valueFrom:
+              secretKeyRef:
+                key: admin
+                name: alertmanager-bot
+          - name: TELEGRAM_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: token
+                name: alertmanager-bot
+          image: metalmatze/alertmanager-bot:0.4.2
+          imagePullPolicy: IfNotPresent
+          name: alertmanager-bot
+          ports:
+          - containerPort: 8080
+            name: http
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 25m
+              memory: 64Mi
+          volumeMounts:
+          - mountPath: /data
+            name: data
+        restartPolicy: Always
+        volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: data
+    volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        labels:
+          app.kubernetes.io/name: alertmanager-bot
+        name: alertmanager-bot
+        namespace: monitoring
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        storageClassName: standard
+kind: List

--- a/deployments/examples/values.jsonnet
+++ b/deployments/examples/values.jsonnet
@@ -1,0 +1,62 @@
+{
+  name: 'alertmanager-bot',
+  image: 'metalmatze/alertmanager-bot:0.4.2',
+
+  alertmanager: {
+    url: 'http://localhost:9093',
+  },
+
+  // This is just an example!
+  // Remove this from jsonnet and create a proper secret!
+  telegram: {
+    admin: '1234',
+    token: 'XXXXXXX',
+  },
+
+  ports: {
+    http: 8080,
+  },
+
+  listen: {
+    addr: '0.0.0.0:%d' % $.ports.http,
+  },
+
+  log: {
+    level: 'info',  // debug info warn error
+    json: false,
+  },
+
+  storage: {
+    bolt: {
+      path: '/data/bot.db',
+    },
+    // consul: {
+    //   url: 'localhost:8500',
+    // },
+  },
+
+  template: {
+    path: '/templates/default.tmpl',
+  },
+
+  // Kubernetes only
+
+  metadata+: {
+    namespace: 'monitoring',
+  },
+  replicas: 1,
+  resources: {
+    limits: {
+      cpu: '100m',
+      memory: '128Mi',
+    },
+    requests: {
+      cpu: '25m',
+      memory: '64Mi',
+    },
+  },
+  pvc: {
+    size: '1Gi',
+    class: 'standard',
+  },
+}

--- a/deployments/kubernetes.libsonnet
+++ b/deployments/kubernetes.libsonnet
@@ -1,0 +1,121 @@
+function(params) {
+  local bot = {
+    local b = self,
+    metadata: {
+      name: b.name,
+      namespace: 'monitoring',
+      labels: {
+        'app.kubernetes.io/name': b.name,
+      },
+    },
+    replicas: 1,
+    resources: {},
+  } + params,
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: bot.metadata,
+    spec: {
+      ports: [
+        { name: name, port: bot.ports[name], targetPort: bot.ports[name] }
+        for name in std.objectFields(bot.ports)
+      ],
+      selector: bot.metadata.labels,
+    },
+  },
+
+  secret: if std.objectHas(bot, 'telegram') then {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: bot.metadata,
+    type: 'Opaque',
+    data: {
+      admin: std.base64(bot.telegram.admin),
+      token: std.base64(bot.telegram.token),
+    },
+  } else null,
+
+  statefulSet: {
+    apiVersion: 'apps/v1',
+    kind: 'StatefulSet',
+    metadata: bot.metadata,
+    spec: {
+      podManagementPolicy: 'OrderedReady',
+      replicas: bot.replicas,
+      selector: {
+        matchLabels: bot.metadata.labels,
+      },
+      serviceName: bot.metadata.name,
+      template: {
+        metadata: bot.metadata,
+        spec: {
+          containers: [
+            {
+              name: bot.name,
+              image: bot.image,
+              imagePullPolicy: 'IfNotPresent',
+              args: [
+                '--alertmanager.url=%s' % bot.alertmanager.url,
+                '--log.level=%s' % bot.log.level,
+              ] + (
+                if bot.log.json then ['--log.json'] else []
+              ) + (
+                if std.objectHas(bot.storage, 'bolt') then [
+                  '--store=bolt',
+                  '--bolt.path=%s' % bot.storage.bolt.path,
+                ] else []
+              ) + (
+                if std.objectHas(bot.storage, 'consul') then [
+                  '--store=consul',
+                  '--consul.url=%s' % bot.storage.consul.url,
+                ] else []
+              ),
+              env: if std.objectHas(bot, 'telegram') then [
+                {
+                  name: 'TELEGRAM_ADMIN',
+                  valueFrom: { secretKeyRef: {
+                    name: bot.metadata.name,
+                    key: 'admin',
+                  } },
+                },
+                {
+                  name: 'TELEGRAM_TOKEN',
+                  valueFrom: { secretKeyRef: {
+                    name: bot.metadata.name,
+                    key: 'token',
+                  } },
+                },
+              ] else [],
+              ports: [
+                { name: name, containerPort: bot.ports[name] }
+                for name in std.objectFields(bot.ports)
+              ],
+              resources: bot.resources,
+              volumeMounts: [
+                { mountPath: '/data', name: 'data' },
+              ],
+            },
+          ],
+          volumes: if std.objectHas(bot, 'pvc') then [
+            { name: 'data', persistentVolumeClaim: { claimName: 'data' } },
+          ] else [
+            { name: 'data', emptyDir: {} },
+          ],
+        },
+      },
+      volumeClaimTemplates: if std.objectHas(bot, 'pvc') then [
+        {
+          apiVersion: 'v1',
+          kind: 'PersistentVolumeClaim',
+          metadata: bot.metadata,
+          spec: {
+            accessModes: ['ReadWriteOnce'],
+            resources: { requests: { storage: bot.pvc.size } },
+            storageClassName: bot.pvc.class,
+          },
+        },
+      ] else [],
+    },
+  },
+}


### PR DESCRIPTION
There's a high-level `values.jsonnet` in the examples folder that's used by both Kubernetes and docker-compose to generate the examples.

What do you think of this style, @squat?
How does it look to you @ekeih?
