### PR TITLE
Send webhooks to /webhooks/telegram/{chatid}

### DIFF
--- a/pkg/alertmanager/webhook.go
+++ b/pkg/alertmanager/webhook.go
@@ -3,6 +3,8 @@ package alertmanager
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -10,8 +12,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// HandleWebhook returns a HandlerFunc that forwards webhooks to all bots via a channel.
-func HandleWebhook(logger log.Logger, counter prometheus.Counter, webhooks chan<- webhook.Message) http.HandlerFunc {
+type TelegramWebhook struct {
+	ChatID  int64
+	Message webhook.Message
+}
+
+// HandleTelegramWebhook returns a HandlerFunc that forwards webhooks to all bots via a channel.
+func HandleTelegramWebhook(logger log.Logger, counter prometheus.Counter, webhooks chan<- TelegramWebhook) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -24,10 +31,16 @@ func HandleWebhook(logger log.Logger, counter prometheus.Counter, webhooks chan<
 		}
 		defer r.Body.Close()
 
-		var webhook webhook.Message
-
-		err := json.NewDecoder(r.Body).Decode(&webhook)
+		chatID, err := strconv.ParseInt(strings.TrimPrefix(r.URL.Path, "/webhooks/telegram/"), 10, 64)
 		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"unable to parse chat ID to int64"}`))
+			return
+		}
+
+		var message webhook.Message
+
+		if err := json.NewDecoder(r.Body).Decode(&message); err != nil {
 			level.Warn(logger).Log(
 				"msg", "failed to decode webhook message",
 				"err", err,
@@ -38,10 +51,11 @@ func HandleWebhook(logger log.Logger, counter prometheus.Counter, webhooks chan<
 
 		level.Debug(logger).Log(
 			"msg", "received webhook",
-			"alerts", len(webhook.Alerts),
+			"alerts", len(message.Alerts),
+			"chat_id", chatID,
 		)
 
-		webhooks <- webhook
+		webhooks <- TelegramWebhook{ChatID: chatID, Message: message}
 		counter.Inc()
 	}
 }

--- a/pkg/telegram/chats.go
+++ b/pkg/telegram/chats.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/docker/libkv/store"
@@ -36,6 +37,21 @@ func (s *ChatStore) List() ([]*telebot.Chat, error) {
 	}
 
 	return chats, nil
+}
+
+// Get a specific chat by its ID.
+func (s *ChatStore) Get(id telebot.ChatID) (*telebot.Chat, error) {
+	key := fmt.Sprintf("%s/%d", s.storeKeyPrefix, id)
+	kv, err := s.kv.Get(key)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return nil, ChatNotFoundErr
+		}
+		return nil, err
+	}
+	var c *telebot.Chat
+	err = json.Unmarshal(kv.Value, &c)
+	return c, err
 }
 
 // Add a telegram chat to the kv backend.


### PR DESCRIPTION
This should allow for a lot more fine grained control over who receives something.
We still require chats to /start a conversation with the bot first, so that we don't accidentally leak alerts into random chats in case the chatID in the webhook URL was wrong.

What do you think @ekeih @markusressel?