### PR TITLE
Enforce receiver on /alerts based on Telegram chat ID

### DIFF
--- a/pkg/alertmanager/alerts.go
+++ b/pkg/alertmanager/alerts.go
@@ -9,8 +9,11 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-func (c *Client) ListAlerts(ctx context.Context) ([]*types.Alert, error) {
-	getAlerts, err := c.alertmanager.Alert.GetAlerts(alert.NewGetAlertsParams().WithContext(ctx))
+func (c *Client) ListAlerts(ctx context.Context, receiver string, silenced bool) ([]*types.Alert, error) {
+	getAlerts, err := c.alertmanager.Alert.GetAlerts(alert.NewGetAlertsParams().WithContext(ctx).
+		WithReceiver(&receiver).
+		WithSilenced(&silenced),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/alertmanager/client_test.go
+++ b/pkg/alertmanager/client_test.go
@@ -175,7 +175,7 @@ func TestClient(t *testing.T) {
 			Timeout:   false,
 		}}
 
-		alerts, err := client.ListAlerts(context.Background())
+		alerts, err := client.ListAlerts(context.Background(), "", false)
 		require.NoError(t, err)
 		require.Equal(t, expected, alerts)
 	}

--- a/tests/workflows/telegram/alerts_test.go
+++ b/tests/workflows/telegram/alerts_test.go
@@ -2,9 +2,12 @@ package telegram
 
 import (
 	"fmt"
+	"net/http"
+	"testing"
 	"time"
 
 	"github.com/metalmatze/alertmanager-bot/pkg/telegram"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/tucnak/telebot.v2"
 )
 
@@ -25,6 +28,9 @@ var alertsWorkflows = []workflow{{
 	logs: []string{
 		"level=debug msg=\"message received\" text=/alerts",
 	},
+	alertmanagerStatus: func(t *testing.T, r *http.Request) string {
+		return `{"config":{"original":"route:\n  receiver: admin\nreceivers:\n- name: admin\n  webhook_configs:\n  - send_resolved: true\n    url: http://localhost:8080/webhooks/telegram/123"}}`
+	},
 }, {
 	name: "AlertsFiring",
 	messages: []telebot.Update{{
@@ -42,11 +48,52 @@ var alertsWorkflows = []workflow{{
 	logs: []string{
 		"level=debug msg=\"message received\" text=/alerts",
 	},
-	alertmanagerAlerts: func() string {
+	alertmanagerAlerts: func(t *testing.T, r *http.Request) string {
+		require.Equal(t, "true", r.URL.Query().Get("active"))
+		require.Equal(t, "true", r.URL.Query().Get("inhibited"))
+		require.Equal(t, "admin", r.URL.Query().Get("receiver"))
+		require.Equal(t, "false", r.URL.Query().Get("silenced"))
+		require.Equal(t, "true", r.URL.Query().Get("unprocessed"))
+
 		return fmt.Sprintf(
 			`[{"labels":{"alertname":"damn","bot":"alertmanager-bot"},"annotations":{"msg":"sup?!","runbook":"https://example.com/runbook"},"startsAt":"%s"}]`,
 			time.Now().Add(-time.Hour).Format(time.RFC3339),
 		)
+	},
+	alertmanagerStatus: func(t *testing.T, r *http.Request) string {
+		return `{"config":{"original":"route:\n  receiver: admin\nreceivers:\n- name: admin\n  webhook_configs:\n  - send_resolved: true\n    url: http://localhost:8080/webhooks/telegram/123"}}`
+	},
+}, {
+	name: "AlertsFiringSilenced",
+	messages: []telebot.Update{{
+		Message: &telebot.Message{
+			Sender: admin,
+			Chat:   chatFromUser(admin),
+			Text:   telegram.CommandAlerts + " silenced",
+		},
+	}},
+	replies: []reply{{
+		recipient: "123",
+		message:   "🔥 <b>damn</b> 🔥\n<b>Labels:</b>\n    bot: alertmanager-bot\n<b>Annotations:</b>\n    msg: sup?!\n    runbook: https://example.com/runbook\n<b>Duration:</b> 1 hour",
+	}},
+	counter: map[string]uint{telegram.CommandAlerts: 1},
+	logs: []string{
+		"level=debug msg=\"message received\" text=\"/alerts silenced\"",
+	},
+	alertmanagerAlerts: func(t *testing.T, r *http.Request) string {
+		require.Equal(t, "true", r.URL.Query().Get("active"))
+		require.Equal(t, "true", r.URL.Query().Get("inhibited"))
+		require.Equal(t, "admin", r.URL.Query().Get("receiver"))
+		require.Equal(t, "true", r.URL.Query().Get("silenced"))
+		require.Equal(t, "true", r.URL.Query().Get("unprocessed"))
+
+		return fmt.Sprintf(
+			`[{"labels":{"alertname":"damn","bot":"alertmanager-bot"},"annotations":{"msg":"sup?!","runbook":"https://example.com/runbook"},"startsAt":"%s"}]`,
+			time.Now().Add(-time.Hour).Format(time.RFC3339),
+		)
+	},
+	alertmanagerStatus: func(t *testing.T, r *http.Request) string {
+		return `{"config":{"original":"route:\n  receiver: admin\nreceivers:\n- name: admin\n  webhook_configs:\n  - send_resolved: true\n    url: http://localhost:8080/webhooks/telegram/123"}}`
 	},
 }, {
 	name: "AlertsResolved",
@@ -65,11 +112,40 @@ var alertsWorkflows = []workflow{{
 	logs: []string{
 		"level=debug msg=\"message received\" text=/alerts",
 	},
-	alertmanagerAlerts: func() string {
+	alertmanagerAlerts: func(t *testing.T, r *http.Request) string {
+		require.Equal(t, "true", r.URL.Query().Get("active"))
+		require.Equal(t, "true", r.URL.Query().Get("inhibited"))
+		require.Equal(t, "admin", r.URL.Query().Get("receiver"))
+		require.Equal(t, "false", r.URL.Query().Get("silenced"))
+		require.Equal(t, "true", r.URL.Query().Get("unprocessed"))
+
 		return fmt.Sprintf(
 			`[{"labels":{"alertname":"damn","bot":"alertmanager-bot"},"annotations":{"msg":"sup?!"},"startsAt": "%s","endsAt": "%s"}]`,
 			time.Now().Add(-time.Hour).Format(time.RFC3339),
 			time.Now().Add(-2*time.Minute).Format(time.RFC3339),
 		)
+	},
+	alertmanagerStatus: func(t *testing.T, r *http.Request) string {
+		return `{"config":{"original":"route:\n  receiver: admin\nreceivers:\n- name: admin\n  webhook_configs:\n  - send_resolved: true\n    url: http://localhost:8080/webhooks/telegram/123"}}`
+	},
+}, {
+	name: "AlertsNotSetup",
+	messages: []telebot.Update{{
+		Message: &telebot.Message{
+			Sender: admin,
+			Chat:   chatFromUser(admin),
+			Text:   telegram.CommandAlerts,
+		},
+	}},
+	replies: []reply{{
+		recipient: "123",
+		message:   "This chat hasn't been setup to receive any alerts yet... 😕\n\nAsk an administrator of the Alertmanager to add a webhook with `/webhooks/telegram/123` as URL.",
+	}},
+	counter: map[string]uint{telegram.CommandAlerts: 1},
+	logs: []string{
+		"level=debug msg=\"message received\" text=/alerts",
+	},
+	alertmanagerStatus: func(t *testing.T, r *http.Request) string {
+		return `{"config":{"original":"route:\n  receiver: admin\nreceivers:\n- name: admin\n  webhook_configs:\n  - send_resolved: true\n    url: http://localhost:8080/webhooks/telegram/unknown"}}`
 	},
 }}

--- a/tests/workflows/telegram/status_test.go
+++ b/tests/workflows/telegram/status_test.go
@@ -2,6 +2,8 @@ package telegram
 
 import (
 	"fmt"
+	"net/http"
+	"testing"
 	"time"
 
 	"github.com/metalmatze/alertmanager-bot/pkg/telegram"
@@ -25,7 +27,7 @@ var statusWorkflows = []workflow{{
 	logs: []string{
 		"level=debug msg=\"message received\" text=/status",
 	},
-	alertmanagerStatus: func() string {
+	alertmanagerStatus: func(t *testing.T, r *http.Request) string {
 		return fmt.Sprintf(
 			`{"uptime":%q,"versionInfo":{"version":"alertmanager"}}`,
 			time.Now().Add(-time.Minute).Format(time.RFC3339),

--- a/tests/workflows/telegram/telegram_test.go
+++ b/tests/workflows/telegram/telegram_test.go
@@ -28,8 +28,8 @@ type workflow struct {
 	counter  map[string]uint
 
 	webhooks           func() []alertmanager.TelegramWebhook
-	alertmanagerAlerts func() string
-	alertmanagerStatus func() string
+	alertmanagerAlerts func(t *testing.T, r *http.Request) string
+	alertmanagerStatus func(t *testing.T, r *http.Request) string
 }
 
 var (
@@ -207,15 +207,15 @@ func (t *testPoller) Poll(_ *telebot.Bot, updates chan telebot.Update, stop chan
 }
 
 func TestWorkflows(t *testing.T) {
-	var testAlertmanagerAlerts func() string
-	var testAlertmanagerStatus func() string
+	var testAlertmanagerAlerts func(t *testing.T, r *http.Request) string
+	var testAlertmanagerStatus func(t *testing.T, r *http.Request) string
 	var am *alertmanager.Client
 	{
 		m := http.NewServeMux()
 		m.HandleFunc("/api/v2/alerts", func(w http.ResponseWriter, r *http.Request) {
 			data := "[]"
 			if testAlertmanagerAlerts != nil {
-				data = testAlertmanagerAlerts()
+				data = testAlertmanagerAlerts(t, r)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(data))
@@ -223,7 +223,7 @@ func TestWorkflows(t *testing.T) {
 		m.HandleFunc("/api/v2/status", func(w http.ResponseWriter, r *http.Request) {
 			data := "{}"
 			if testAlertmanagerStatus != nil {
-				data = testAlertmanagerStatus()
+				data = testAlertmanagerStatus(t, r)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(data))


### PR DESCRIPTION
Going forward the bot will do a reverse lookup of the Chat ID in the Alertmanager config to find the receiver name. Once a receiver is found the bot will only query for alerts with that receiver. Basically `/api/v2/alerts?receiver=admin`.

Additionally the `/alerts `command is able to handle another payload/argument to show all silenced alerts too. 
`/alerts` - shows all alerts for the receiver/chat without the silenced ones.
`/alerts silenced`- shows all alerts for the receiver/chat with the silenced ones.

### Some screenshots

For this chat/receiver there are currently no alerts at all - not even silenced ones. 
![Screenshot from 2021-02-24 19-19-07](https://user-images.githubusercontent.com/872251/109048384-502b6700-76d7-11eb-88ed-caf4b713ef4b.png)

For this chat/receiver there are currently no alerts (but silenced ones are hidden).
![Screenshot from 2021-02-24 19-19-27](https://user-images.githubusercontent.com/872251/109048385-50c3fd80-76d7-11eb-9c7f-6a154d1a1556.png)
With the additional `silenced` argument we can show these silencend alerts too. :sunglasses: 
![Screenshot from 2021-02-24 19-19-51](https://user-images.githubusercontent.com/872251/109048388-50c3fd80-76d7-11eb-9334-f9fc2b775791.png)
