### PR TITLE
[Feature] add basic helm chart

### DIFF
--- a/deployments/helm/alertmanager-bot/.helmignore
+++ b/deployments/helm/alertmanager-bot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployments/helm/alertmanager-bot/Chart.yaml
+++ b/deployments/helm/alertmanager-bot/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: alertmanager-bot
+description:  Bot for Prometheus' Alertmanager 
+type: application
+version: 0.1.0
+appVersion: "v0.4.3"
+home: https://github.com/metalmatze/alertmanager-bot
+sources:
+  - https://github.com/metalmatze/alertmanager-bot

--- a/deployments/helm/alertmanager-bot/README.md
+++ b/deployments/helm/alertmanager-bot/README.md
@@ -1,0 +1,1 @@
+# Helm Chart for alertmanager-bot

--- a/deployments/helm/alertmanager-bot/templates/_helpers.tpl
+++ b/deployments/helm/alertmanager-bot/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alertmanager-bot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alertmanager-bot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alertmanager-bot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "alertmanager-bot.labels" -}}
+helm.sh/chart: {{ include "alertmanager-bot.chart" . }}
+{{ include "alertmanager-bot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alertmanager-bot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alertmanager-bot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "alertmanager-bot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "alertmanager-bot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployments/helm/alertmanager-bot/templates/secret.yaml
+++ b/deployments/helm/alertmanager-bot/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if (not .Values.secret.existingSecret ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alertmanager-bot.fullname" . }}
+type: Opaque
+data:
+  admin: "{{ .Values.secret.adminUser | b64enc }}"
+  token: "{{ .Values.secret.botToken | b64enc }}"
+{{- end }}

--- a/deployments/helm/alertmanager-bot/templates/service.yaml
+++ b/deployments/helm/alertmanager-bot/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alertmanager-bot.fullname" . }}
+  labels:
+    {{- include "alertmanager-bot.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "alertmanager-bot.selectorLabels" . | nindent 4 }}

--- a/deployments/helm/alertmanager-bot/templates/statefulset.yaml
+++ b/deployments/helm/alertmanager-bot/templates/statefulset.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "alertmanager-bot.fullname" . }}
+  labels:
+    {{- include "alertmanager-bot.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "alertmanager-bot.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "alertmanager-bot.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "alertmanager-bot.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: alertmanager-bot
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        args:
+          - --alertmanager.url={{ .Values.config.alertmanagerUrl }}
+          - --log.level={{ .Values.config.logLevel | default "info" }}
+          - --store=bolt
+          - --bolt.path=/data/bot.db
+        env:
+          - name: TELEGRAM_ADMIN
+            valueFrom:
+              secretKeyRef:
+                key: adminUser
+                name: {{ .Values.secret.existingSecret | default (include "alertmanager-bot.fullname" .) }}
+          - name: TELEGRAM_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: botToken
+                name: {{ .Values.secret.existingSecret | default (include "alertmanager-bot.fullname" .) }}
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | default "1Gi" }}
+      storageClassName: {{ .Values.persistence.storageClassName | default "default" }}

--- a/deployments/helm/alertmanager-bot/templates/tests/test-connection.yaml
+++ b/deployments/helm/alertmanager-bot/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "alertmanager-bot.fullname" . }}-test-connection"
+  labels:
+    {{- include "alertmanager-bot.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "alertmanager-bot.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deployments/helm/alertmanager-bot/values.yaml
+++ b/deployments/helm/alertmanager-bot/values.yaml
@@ -1,0 +1,34 @@
+# Default values for alertmanager-bot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: metalmatze/alertmanager-bot
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.4.3"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+secret:
+  # existingSecret: ""
+  adminUser: "" # not used if existingSecret is set
+  botToken: "" # not used if existingSecret is set
+
+config:
+  alertmanagerUrl: http://alertmanager:9093
+  logLevel: info
+
+persistence:
+  size: 1Gi
+  storageClassName: local-path # default storageClass in K3s


### PR DESCRIPTION
Super basic helm chart based on the StatefulSet example that I used to deploy to my K3s cluster.
There are certainly many more options to expose, but this should take it off the ground.

FWIW: Just gave this bot a try today and absolutely love it, thank you!