### PR TITLE
Fixing empty subscribed user list '@'

### DIFF
--- a/pkg/telegram/bot.go
+++ b/pkg/telegram/bot.go
@@ -383,8 +383,10 @@ func (b *Bot) handleChats(message *telebot.Message) error {
 	for _, chat := range chats {
 		if chat.Type == telebot.ChatGroup {
 			list = list + fmt.Sprintf("@%s\n", chat.Title)
-		} else {
+		} else if len(chat.Username) > 0 {
 			list = list + fmt.Sprintf("@%s\n", chat.Username)
+		} else {
+			list = list + fmt.Sprintf("@%d\n", chat.ID)
 		}
 	}
 

--- a/pkg/telegram/bot.go
+++ b/pkg/telegram/bot.go
@@ -36,10 +36,11 @@ const (
 	responseAlertsNotConfigured = "This chat hasn't been setup to receive any alerts yet... 😕\n\n" +
 		"Ask an administrator of the Alertmanager to add a webhook with `/webhooks/telegram/%d` as URL."
 
-	responseStartPrivate = "Hey, %s! I will now keep you up to date!\n" + CommandHelp
-	responseStartGroup   = "Hey! I will now keep you all up to date!\n" + CommandHelp
-	responseStop         = "Alright, %s! I won't talk to you again.\n" + CommandHelp
-	ResponseHelp         = `
+	responseStartPrivate          = "Hey, %s! I will now keep you up to date!\n" + CommandHelp
+	responseStartPrivateAnonymous = "Hey! I will now keep you up to date!\n" + CommandHelp
+	responseStartGroup            = "Hey! I will now keep you all up to date!\n" + CommandHelp
+	responseStop                  = "Alright, %s! I won't talk to you again.\n" + CommandHelp
+	ResponseHelp                  = `
 I'm a Prometheus AlertManager Bot for Telegram. I will notify you about alerts.
 You can also ask me about my ` + CommandStatus + `, ` + CommandAlerts + ` & ` + CommandSilences + `
 
@@ -337,8 +338,14 @@ func (b *Bot) handleStart(message *telebot.Message) error {
 	)
 
 	if message.Chat.Type == telebot.ChatPrivate {
-		_, err := b.telegram.Send(message.Chat, fmt.Sprintf(responseStartPrivate, message.Sender.FirstName))
-		return err
+		if len(message.Sender.FirstName) > 0 {
+			_, err := b.telegram.Send(message.Chat, fmt.Sprintf(responseStartPrivate, message.Sender.FirstName))
+			return err
+		} else {
+			_, err := b.telegram.Send(message.Chat, responseStartPrivateAnonymous)
+			return err
+		}
+
 	} else {
 		_, err := b.telegram.Send(message.Chat, responseStartGroup)
 		return err

--- a/tests/workflows/telegram/chats_test.go
+++ b/tests/workflows/telegram/chats_test.go
@@ -53,4 +53,35 @@ var chatsWorkflows = []workflow{{
 		"level=info msg=\"user subscribed\" username=elliot user_id=123 chat_id=123",
 		"level=debug msg=\"message received\" text=/chats",
 	},
+}, {
+	name: "ChatsWithNoUsernameSubscribed",
+	messages: []telebot.Update{{
+		Message: &telebot.Message{
+			Sender: anonymousAdmin,
+			Chat:   chatFromUser(anonymousAdmin),
+			Text:   telegram.CommandStart,
+		},
+	}, {
+		Message: &telebot.Message{
+			Sender: anonymousAdmin,
+			Chat:   chatFromUser(anonymousAdmin),
+			Text:   telegram.CommandChats,
+		},
+	}},
+	replies: []reply{{
+		recipient: "123",
+		message:   "Hey! I will now keep you up to date!\n/help",
+	}, {
+		recipient: "123",
+		message:   "Currently these chat have subscribed:\n@123",
+	}},
+	counter: map[string]uint{
+		telegram.CommandChats: 1,
+		telegram.CommandStart: 1,
+	},
+	logs: []string{
+		"level=debug msg=\"message received\" text=/start",
+		"level=info msg=\"user subscribed\" username= user_id=123 chat_id=123",
+		"level=debug msg=\"message received\" text=/chats",
+	},
 }}

--- a/tests/workflows/telegram/telegram_test.go
+++ b/tests/workflows/telegram/telegram_test.go
@@ -47,6 +47,11 @@ var (
 		Username:  "nobody",
 		IsBot:     false,
 	}
+	// The admin is determined by ID, so we can use different user objects with the same ID in the tests without creating inconsistent state.
+	anonymousAdmin = &telebot.User{
+		ID:    123,
+		IsBot: false,
+	}
 
 	webhookFiring = webhook.Message{
 		Data: &template.Data{


### PR DESCRIPTION
chat.Username is not always set. "len(string) > 0" evaluates to false for both the empty string and nil.

Closes https://github.com/metalmatze/alertmanager-bot/issues/196

this was not tested